### PR TITLE
feat: chart

### DIFF
--- a/src/components/common/IdolImage.jsx
+++ b/src/components/common/IdolImage.jsx
@@ -10,14 +10,16 @@ const IdolImage = ({
   checkIconSize = "30px",
 }) => {
   return (
-    <div
-      className="imgBorder"
-      style={{ "--size": size, "--check-icon-size": checkIconSize }}
-    >
+    <div className="imgBorder" style={{ "--size": size }}>
       <img src={src} alt={alt} className="idolImg" />
       {isActive && (
         <div className="idolOverlay">
-          <img src={checkIcon} alt="체크 표시" className="checkedIcon" />
+          <img
+            src={checkIcon}
+            alt="체크 표시"
+            className="checkedIcon"
+            style={{ width: checkIconSize, height: checkIconSize }}
+          />
         </div>
       )}
     </div>

--- a/src/components/common/IdolImage.jsx
+++ b/src/components/common/IdolImage.jsx
@@ -1,10 +1,25 @@
 import React from "react";
 import "./IdolImage.scss";
+import checkIcon from "../../assets/icons/check.svg";
 
-const IdolImage = ({ src, alt = "IdolImage", size = "70px" }) => {
+const IdolImage = ({
+  src,
+  alt = "IdolImage",
+  size = "70px",
+  isActive,
+  checkIconSize = "30px",
+}) => {
   return (
-    <div className="imgBorder" style={{ "--size": size }}>
+    <div
+      className="imgBorder"
+      style={{ "--size": size, "--check-icon-size": checkIconSize }}
+    >
       <img src={src} alt={alt} className="idolImg" />
+      {isActive && (
+        <div className="idolOverlay">
+          <img src={checkIcon} alt="체크 표시" className="checkedIcon" />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/common/IdolImage.scss
+++ b/src/components/common/IdolImage.scss
@@ -17,3 +17,16 @@
   border-radius: 50%;
   object-fit: cover;
 }
+
+.idolOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: transparentize($color-brand-peach, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}

--- a/src/components/common/IdolImage.scss
+++ b/src/components/common/IdolImage.scss
@@ -4,7 +4,7 @@
   width: var(--size);
   height: var(--size);
   border-radius: 50%;
-  border: 3px solid $color-brand-peach;
+  border: 1px solid $color-brand-peach;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/common/IdolImage.scss
+++ b/src/components/common/IdolImage.scss
@@ -18,6 +18,11 @@
   object-fit: cover;
 }
 
+.imgBorder .checkedIcon {
+  width: var(--check-icon-size);
+  height: var(--check-icon-size);
+}
+
 .idolOverlay {
   position: absolute;
   top: 0;

--- a/src/components/modals/VoteIdol.jsx
+++ b/src/components/modals/VoteIdol.jsx
@@ -1,4 +1,3 @@
-import checkIcon from "../../assets/icons/check.svg";
 import IdolImage from "../common/IdolImage";
 import "./VoteIdol.scss";
 
@@ -6,12 +5,11 @@ const VoteIdol = ({ rank, idol, isActive }) => {
   return (
     <div className="modalIdolInfo">
       <div className="modalImageContainer">
-        <IdolImage src={idol.profilePicture} alt={idol.name} />
-        {isActive && (
-          <div className="overlay">
-            <img src={checkIcon} alt="체크 표시" className="checkedIcon" />
-          </div>
-        )}
+        <IdolImage
+          src={idol.profilePicture}
+          alt={idol.name}
+          isActive={isActive}
+        />
       </div>
       <span className="modalIdolRank">{rank}</span>
       <div className="modalIdolContents">

--- a/src/components/modals/VoteIdol.scss
+++ b/src/components/modals/VoteIdol.scss
@@ -27,21 +27,3 @@
   flex-direction: column;
   gap: 3px;
 }
-
-.overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: transparentize($color-brand-peach, 0.6); /* 분홍색 배경 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-}
-
-.checkedIcon {
-  width: 30px;
-  height: 30px;
-}


### PR DESCRIPTION
- [x] 아이돌 이미지 보더 값을 변경했습니다.

- [x] 기존 VoteIdol 컴포넌트에 있던 아이돌 선택 시 체크 표시와 오버레이 코드를 재사용 가능하게 IdolImage 컴포넌트로 이동하고 VoteIdol 컴포넌트에선 isActive 값만 받게 변경하였습니다. 

추가적으로 IdolImage 컴포넌트에 checkIconSize="52px" 이런식으로 프롭을 활용하면 체크아이콘 크기를 변경할 수 있습니다.

오버레이와 체크아이콘 코드를 제가 작성한게 아니라서 정확한 구조는 파악이 안 됐습니다 ㅜㅜ... 
이달의 차트 투표하기에서는 잘 작동하는데 다른 컴포넌트에서 활용해도 작동하는지 여부는 태환님 코드가 아직 머지가 안 되어서 확인은 못해봤습니다. 
혹여나 위 컴포넌트가 잘 작동하지 않는다면 억지로 사용하실 필요는 없고 아이돌이미지 컴포넌트는 이달의 차트와 투표하기 기능에서만 활용하도록 할게요!

멘토님께서 딜리트버튼을 프롭으로 주는 것도 고려해보라고 하셨는데 그 부분은 딜리트 버튼을 활용하는 곳이 마이페이지밖에 없고 관련 코드도 저한테 없어서 따로 추가하진 않았습니다. 아이돌 이미지 컴포넌트에는 크게 추가하지 않아도 되는 부분이라고 생각하는데 다른 의견 있으면 남겨주세요.