### PR TITLE
feat: intro

### DIFF
--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "./LandingPage.scss";
 import fandomKLogo from "../../assets/images/Fandom-K.png";
+import introLogo from "../../assets/images/logo.png";
 import main from "../../assets/images/main.png";
 import home1 from "../../assets/images/Home-1.png";
 import home2 from "../../assets/images/Home-2.png";
@@ -12,14 +13,34 @@ import { useNavigate } from "react-router-dom";
 import { useCredit } from "../../hooks/useCredit";
 
 function LandingPage() {
+  const [showIntro, setShowIntro] = useState(true); // 인트로 상태
   const navigate = useNavigate();
   const { dispatch } = useCredit();
+
+  useEffect(() => {
+    //인트로를 2초간 보여줄 useEffect
+    const timer = setTimeout(() => {
+      setShowIntro(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   const moveToList = () => {
     localStorage.clear();
     dispatch({ type: "setCredits", amount: 0 });
     navigate("/list");
   };
+
+  if (showIntro) {
+    // 인트로페이지
+    return (
+      <div className="introPage">
+        <div className="backgroundImage" />
+        <img src={introLogo} className="introLogo" alt="팬덤케이" />
+      </div>
+    );
+  }
 
   return (
     <div className="all">
@@ -62,15 +83,10 @@ function LandingPage() {
           </div>
 
           <div className="home1">
-            <img
-              src={home1}
-              className="phoneImage"
-              alt="phone screen 1"
-            />
+            <img src={home1} className="phoneImage" alt="phone screen 1" />
           </div>
 
-          <div className="navyStripe">
-          </div>
+          <div className="navyStripe"></div>
         </div>
       </section>
 
@@ -89,11 +105,7 @@ function LandingPage() {
           </div>
 
           <div className="home2">
-            <img
-              src={home2}
-              className="phoneImage"
-              alt="phone screen 2"
-            />
+            <img src={home2} className="phoneImage" alt="phone screen 2" />
           </div>
         </div>
       </section>
@@ -113,11 +125,7 @@ function LandingPage() {
           </div>
 
           <div className="home3">
-            <img
-              src={home3}
-              className="phoneImage"
-              alt="phone screen 3"
-            />
+            <img src={home3} className="phoneImage" alt="phone screen 3" />
           </div>
         </div>
       </section>

--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -14,13 +14,14 @@ import { useCredit } from "../../hooks/useCredit";
 
 function LandingPage() {
   const [showIntro, setShowIntro] = useState(true); // 인트로 상태
+  const [fadeOut, setFadeOut] = useState(false); //페이드 아웃
   const navigate = useNavigate();
   const { dispatch } = useCredit();
 
   useEffect(() => {
-    //인트로를 2초간 보여줄 useEffect
     const timer = setTimeout(() => {
-      setShowIntro(false);
+      setFadeOut(true);
+      setTimeout(() => setShowIntro(false), 500);
     }, 2000);
 
     return () => clearTimeout(timer);
@@ -33,10 +34,8 @@ function LandingPage() {
   };
 
   if (showIntro) {
-    // 인트로페이지
     return (
-      <div className="introPage">
-        <div className="backgroundImage" />
+      <div className={`introPage ${fadeOut ? "fade-out zoom-out" : ""}`}>
         <img src={introLogo} className="introLogo" alt="팬덤케이" />
       </div>
     );

--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -19,9 +19,13 @@ function LandingPage() {
   const { dispatch } = useCredit();
 
   useEffect(() => {
+    document.body.style.overflow = "hidden";
     const timer = setTimeout(() => {
       setFadeOut(true);
-      setTimeout(() => setShowIntro(false), 500);
+      setTimeout(() => {
+        setShowIntro(false);
+        document.body.style.overflow = "auto";
+      }, 500);
     }, 2000);
 
     return () => clearTimeout(timer);

--- a/src/pages/LandingPage/LandingPage.scss
+++ b/src/pages/LandingPage/LandingPage.scss
@@ -1,3 +1,37 @@
+@import "../../styles/global.scss";
+
+// 인트로 스타일
+.introPage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+  background-color: $color-black-1;
+}
+
+.backgroundImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url("../../assets/images/main.png");
+  background-size: cover;
+  background-position: center;
+  opacity: 0.25;
+  filter: blur(5px);
+  z-index: 1;
+}
+
+.introLogo {
+  width: 250px;
+  height: auto;
+  z-index: 2;
+}
+
+//여기부터 랜딩페이지 스타일
 .all {
   height: 100%;
   width: 100%;
@@ -14,8 +48,8 @@
     position: relative;
   }
 
-  .donateIntro, 
-  .artistNewsIntro, 
+  .donateIntro,
+  .artistNewsIntro,
   .monthlyArtistIntro {
     height: 1200px;
     display: flex;
@@ -38,9 +72,7 @@
     line-height: 31.03px;
   }
 
-  
-
-  .imageBox { 
+  .imageBox {
     position: absolute;
     top: 0px;
     left: 50%;
@@ -48,11 +80,11 @@
     width: 1080px;
     height: 1080px;
     mask-image: linear-gradient(
-      90deg, 
-      rgba(217, 217, 217, 0) 0%, 
-      rgba(217, 217, 217, 0.4) 30.73%, 
-      rgba(217, 217, 217, 0.6) 51.04%, 
-      rgba(217, 217, 217, 0.4) 71.87%, 
+      90deg,
+      rgba(217, 217, 217, 0) 0%,
+      rgba(217, 217, 217, 0.4) 30.73%,
+      rgba(217, 217, 217, 0.6) 51.04%,
+      rgba(217, 217, 217, 0.4) 71.87%,
       rgba(217, 217, 217, 0) 100%
     );
 
@@ -77,8 +109,8 @@
     border-radius: 0;
   }
 
-  .donateIntroText, 
-  .voteIntroText, 
+  .donateIntroText,
+  .voteIntroText,
   .newsIntroText {
     position: absolute;
     height: 85px;
@@ -97,8 +129,15 @@
     top: 2000px;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: linear-gradient(180deg, #030615 0%, #051D31 42.67%, #051E32 53.12%, #051C30 74.27%, #030B1C 100%);
-    z-index: 2; 
+    background: linear-gradient(
+      180deg,
+      #030615 0%,
+      #051d31 42.67%,
+      #051e32 53.12%,
+      #051c30 74.27%,
+      #030b1c 100%
+    );
+    z-index: 2;
   }
 
   .mainTitle {
@@ -123,11 +162,11 @@
     width: 1200px;
     height: 1200px;
     mask-image: linear-gradient(
-      90deg, 
-      rgba(217, 217, 217, 0) 0%, 
-      rgba(217, 217, 217, 0.4) 30.73%, 
-      rgba(217, 217, 217, 0.6) 51.04%, 
-      rgba(217, 217, 217, 0.4) 71.87%, 
+      90deg,
+      rgba(217, 217, 217, 0) 0%,
+      rgba(217, 217, 217, 0.4) 30.73%,
+      rgba(217, 217, 217, 0.6) 51.04%,
+      rgba(217, 217, 217, 0.4) 71.87%,
       rgba(217, 217, 217, 0) 100%
     );
   }
@@ -152,7 +191,9 @@
     object-fit: cover;
   }
 
-  .home1,.home2,.home3 {
+  .home1,
+  .home2,
+  .home3 {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -164,7 +205,7 @@
 
   .highlight {
     font-weight: 700;
-    color: #FF3B3B;
+    color: #ff3b3b;
   }
 
   .heading2 {
@@ -207,7 +248,7 @@
     width: 477px;
     top: 670px;
     height: 48px;
-    background: linear-gradient(90deg, #F86F65 0%, #FE5493 100%);
+    background: linear-gradient(90deg, #f86f65 0%, #fe5493 100%);
     border: none;
     color: white;
     font-size: 14px;
@@ -218,7 +259,7 @@
 
   @media (max-width: 744px) {
     .heroSection {
-      height: 1200px;  // 예시: 태블릿에서는 높이를 줄임
+      height: 1200px;
     }
 
     .imageBox {
@@ -258,7 +299,8 @@
       top: 400px;
     }
 
-    .heading, .heading2 {
+    .heading,
+    .heading2 {
       font-size: 20px;
       width: 250px;
     }

--- a/src/pages/LandingPage/LandingPage.scss
+++ b/src/pages/LandingPage/LandingPage.scss
@@ -5,30 +5,24 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
   height: 100vh;
-  overflow: hidden;
   background-color: $color-black-1;
-}
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
 
-.backgroundImage {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image: url("../../assets/images/main.png");
-  background-size: cover;
-  background-position: center;
-  opacity: 0.25;
-  filter: blur(5px);
-  z-index: 1;
+  &.fade-out {
+    opacity: 0;
+  }
+
+  &.zoom-out {
+    transform: scale(1.2);
+  }
 }
 
 .introLogo {
-  width: 250px;
+  width: 300px;
   height: auto;
-  z-index: 2;
 }
 
 //여기부터 랜딩페이지 스타일


### PR DESCRIPTION
랜딩페이지가 렌더링 되기 전에 간단한 인트로가 출력되게 해봤습니다.

bg-img도 넣어보고 여러 속성도 넣어보고 했는데 어차피 잠깐 보여지는 화면인데
화려한 것 보단 심플하게 로고만 보여지는게 좋을 것 같아서 결국 처음으로 돌아와
로고에 페이드 아웃과 확대 애니메이션만 조금 넣어봤습니다.
반응형은 로고 하나 밖에 없기도 하고 배포 후에 확인해볼 내용이라고 생각해서 크게 고려하지 않았고
디자인 적으로 개선할 부분이나 아이디어가 있으시면 바로 말씀해주세요!

IntroPage 컴포넌트를 만들어서 작업하려고 했는데 조건에 랜딩 페이지 구현하기(/) 즉 랜딩 페이지 루트가 /로 설정되어 있어서
/intro로 작업을 해야 하는데 라우터가 잘 안 되더라고요...
그래서 어차피 재활용 하는게 아니라 랜딩 페이지에서만 사용할 테니까 랜딩 페이지 안에서 코드를 작성했습니다.