### PR TITLE
fix: 모달창 오버레이 클릭시 닫히는 로직 수정

### DIFF
--- a/src/components/modals/CommonModal.jsx
+++ b/src/components/modals/CommonModal.jsx
@@ -9,8 +9,7 @@ const CommonModal = ({ isOpen, onClose, title, children }) => {
   };
 
   return (
-    <div className="modalOverlay" onClick={handleOverlayClose}>
-      {" "}
+    <div className="modalOverlay" onMouseDown={handleOverlayClose}>
       {/*오버레이 (화면 어둡게)*/}
       <div className="modal">
         <div className="title">
@@ -20,7 +19,7 @@ const CommonModal = ({ isOpen, onClose, title, children }) => {
             onClick={onClose}
             className="modalClose"
             alt="닫기버튼"
-          />{" "}
+          />
           {/*모달창 닫기버튼*/}
         </div>
         {children} {/*모달의 창의 내용*/}


### PR DESCRIPTION
- 모달창 안 쪽을 눌렀다가 모달창 바깥에서 마우스를 뗐을 때, 모달창이 닫히는 오류가 있어서 모달창 바깥을 누르기만 하면 닫히도록 수정했습니다.